### PR TITLE
Change vikor-compromises 'veto' input name to 'v'

### DIFF
--- a/vikor-compromises/description-wsDDv2.xml
+++ b/vikor-compromises/description-wsDDv2.xml
@@ -30,13 +30,13 @@ This module bases on VIKOR method, from step 3 as a continuation of module `VIKO
             <xmcda tag="alternativesValues"/>
         </input>
 
-        <input id="input4" name="veto" displayName="veto" isoptional="0">
+        <input id="input4" name="v" displayName="v" isoptional="0">
             <documentation>
                 <description>Weight of the strategy of S and R</description>
             </documentation>
             <xmcda tag="methodParameters"><![CDATA[
     <methodParameters>
-        <parameter id="veto">
+        <parameter id="v">
             <value>
                 <real>%1</real>
             </value>
@@ -44,7 +44,7 @@ This module bases on VIKOR method, from step 3 as a continuation of module `VIKO
     </methodParameters>
 ]]></xmcda>
             <gui status="preferGUI">
-                <entry id="%1" type="float" displayName="veto" />
+                <entry id="%1" type="float" displayName="v" />
             </gui>
         </input>
 

--- a/vikor-compromises/description-wsDDv3.xml
+++ b/vikor-compromises/description-wsDDv3.xml
@@ -30,13 +30,13 @@ This module bases on VIKOR method, from step 3 as a continuation of module `VIKO
             <xmcda tag="alternativesValues"/>
         </input>
 
-        <input id="input4" name="veto" displayName="veto" isoptional="0">
+        <input id="input4" name="v" displayName="v" isoptional="0">
             <documentation>
                 <description>Weight of the strategy of S and R</description>
             </documentation>
             <xmcda tag="programParameters"><![CDATA[
     <programParameters>
-        <parameter id="veto">
+        <parameter id="v">
             <values>
                 <value>
                     <real>%1</real>
@@ -46,7 +46,7 @@ This module bases on VIKOR method, from step 3 as a continuation of module `VIKO
     </programParameters>
 ]]></xmcda>
             <gui status="preferGUI">
-                <entry id="%1" type="float" displayName="veto" />
+                <entry id="%1" type="float" displayName="v" />
             </gui>
         </input>
 

--- a/vikor-compromises/src/inputsHandler.R
+++ b/vikor-compromises/src/inputsHandler.R
@@ -19,9 +19,9 @@ checkAndExtractInputs <- function(xmcdaData) {
 	r = alternativesValues[[2]]
 
 	parameters = extractProgramParameters(xmcdaData)
-	v = parameters[[1]]$veto[[1]]
+	v = parameters[[1]]$v[[1]]
 	if (is.null(v)) {
-		msg <- "veto value has not been supplied"
+		msg <- "v value has not been supplied"
 		putProgramExecutionResult(xmcdaMessages, errors = msg)
 		return(NULL)
 	}

--- a/vikor-compromises/src/vikorCompromises.R
+++ b/vikor-compromises/src/vikorCompromises.R
@@ -44,7 +44,7 @@ vikorCompromises = function(S, R, v) {
 		! all(is.numeric(R)))
 	stop("'R' must be a non-negative values vector")
 	if (v < 0 || v > 1 || ! is.numeric(v))
-	stop("A numeric value for 'v' (veto) in [0,1] should be provided")
+	stop("A numeric value for 'v' in [0,1] should be provided")
 
 	S = S[order(names(S))]
 	R = R[order(names(R))]

--- a/vikor-compromises/src/vikorCompromisesCLI_XMCDAv2.R
+++ b/vikor-compromises/src/vikorCompromisesCLI_XMCDAv2.R
@@ -36,7 +36,7 @@ dir.create(file.path(outDirectory), showWarnings = FALSE)
 #outDirectory <- "/path/to/vikor/tests/out_tmp/"
 # filenames
 alternativesFile <- "alternatives.xml"
-vetoFile <- "veto.xml"
+vFile <- "v.xml"
 sFile <- "s.xml"
 rFile <- "r.xml"
 qFile <- "q.xml"
@@ -49,7 +49,7 @@ xmcdaData <- .jnew("org/xmcda/XMCDA")
 loadXMCDAv2(xmcdaDatav2, inDirectory, alternativesFile, mandatory = TRUE, xmcdaMessages,"alternatives")
 loadXMCDAv2(xmcdaDatav2, inDirectory, sFile, mandatory = TRUE, xmcdaMessages,"alternativesValues")
 loadXMCDAv2(xmcdaDatav2, inDirectory, rFile, mandatory = TRUE, xmcdaMessages,"alternativesValues")
-loadXMCDAv2(xmcdaDatav2, inDirectory, vetoFile, mandatory = TRUE, xmcdaMessages,"methodParameters")
+loadXMCDAv2(xmcdaDatav2, inDirectory, vFile, mandatory = TRUE, xmcdaMessages,"methodParameters")
 # if we have problem with the inputs, it is time to stop
 if (xmcdaMessages$programExecutionResultsList$size() > 0){
   if (xmcdaMessages$programExecutionResultsList$get(as.integer(0))$isError()){

--- a/vikor-compromises/src/vikorCompromisesCLI_XMCDAv3.R
+++ b/vikor-compromises/src/vikorCompromisesCLI_XMCDAv3.R
@@ -36,7 +36,7 @@ dir.create(file.path(outDirectory), showWarnings = FALSE)
 #outDirectory <- "/path/to/vikor/tests/out_tmp/"
 # filenames
 alternativesFile <- "alternatives.xml"
-vetoFile <- "veto.xml"
+vFile <- "v.xml"
 sFile <- "s.xml"
 rFile <- "r.xml"
 qFile <- "q.xml"
@@ -48,7 +48,7 @@ xmcdaData <- .jnew("org/xmcda/XMCDA")
 loadXMCDAv3(xmcdaData, inDirectory, alternativesFile, mandatory = TRUE, xmcdaMessages, "alternatives")
 loadXMCDAv3(xmcdaData, inDirectory, sFile, mandatory = TRUE, xmcdaMessages, "alternativesValues")
 loadXMCDAv3(xmcdaData, inDirectory, rFile, mandatory = TRUE, xmcdaMessages, "alternativesValues")
-loadXMCDAv3(xmcdaData, inDirectory, vetoFile, mandatory = TRUE, xmcdaMessages, "programParameters")
+loadXMCDAv3(xmcdaData, inDirectory, vFile, mandatory = TRUE, xmcdaMessages, "programParameters")
 # if we have problem with the inputs, it is time to stop
 if (xmcdaMessages$programExecutionResultsList$size() > 0){
   if (xmcdaMessages$programExecutionResultsList$get(as.integer(0))$isError()){

--- a/vikor-compromises/tests/in1.v2/v.xml
+++ b/vikor-compromises/tests/in1.v2/v.xml
@@ -4,7 +4,7 @@
         xmlns:xmcda="http://www.decision-deck.org/2017/XMCDA-2.2.2"
         xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
     <methodParameters>
-        <parameter id="veto">
+        <parameter id="v">
             <value>
                 <real>0.5</real>
             </value>

--- a/vikor-compromises/tests/in1.v3/v.xml
+++ b/vikor-compromises/tests/in1.v3/v.xml
@@ -4,7 +4,7 @@
              xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-3.0.2
               http://www.decision-deck.org/xmcda/_downloads/XMCDA-3.0.2.xsd">
     <programParameters>
-        <parameter id="veto">
+        <parameter id="v">
             <values>
                 <value>
                     <real>0.5</real>

--- a/vikor-compromises/tests/in2.v2/v.xml
+++ b/vikor-compromises/tests/in2.v2/v.xml
@@ -4,7 +4,7 @@
         xmlns:xmcda="http://www.decision-deck.org/2017/XMCDA-2.2.2"
         xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
     <methodParameters>
-        <parameter id="veto">
+        <parameter id="v">
             <value>
                 <real>0.5</real>
             </value>

--- a/vikor-compromises/tests/in2.v3/v.xml
+++ b/vikor-compromises/tests/in2.v3/v.xml
@@ -4,7 +4,7 @@
              xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-3.0.2
               http://www.decision-deck.org/xmcda/_downloads/XMCDA-3.0.2.xsd">
     <programParameters>
-        <parameter id="veto">
+        <parameter id="v">
             <values>
                 <value>
                     <real>0.5</real>

--- a/vikor-compromises/tests/in3.v2/v.xml
+++ b/vikor-compromises/tests/in3.v2/v.xml
@@ -4,7 +4,7 @@
         xmlns:xmcda="http://www.decision-deck.org/2017/XMCDA-2.2.2"
         xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
     <methodParameters>
-        <parameter id="veto">
+        <parameter id="v">
             <value>
                 <real>0.5</real>
             </value>

--- a/vikor-compromises/tests/in3.v3/v.xml
+++ b/vikor-compromises/tests/in3.v3/v.xml
@@ -4,7 +4,7 @@
              xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-3.0.2
               http://www.decision-deck.org/xmcda/_downloads/XMCDA-3.0.2.xsd">
     <programParameters>
-        <parameter id="veto">
+        <parameter id="v">
             <values>
                 <value>
                     <real>0.5</real>

--- a/vikor-compromises/tests/in_error_1.v2/v.xml
+++ b/vikor-compromises/tests/in_error_1.v2/v.xml
@@ -4,7 +4,7 @@
         xmlns:xmcda="http://www.decision-deck.org/2017/XMCDA-2.2.2"
         xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-2.2.2 http://www.decision-deck.org/xmcda/_downloads/XMCDA-2.2.2.xsd">
     <methodParameters>
-        <parameter id="veto">
+        <parameter id="v">
             <value>
                 <real>0.5</real>
             </value>

--- a/vikor-compromises/tests/in_error_1.v3/v.xml
+++ b/vikor-compromises/tests/in_error_1.v3/v.xml
@@ -4,7 +4,7 @@
              xsi:schemaLocation="http://www.decision-deck.org/2017/XMCDA-3.0.2
               http://www.decision-deck.org/xmcda/_downloads/XMCDA-3.0.2.xsd">
     <programParameters>
-        <parameter id="veto">
+        <parameter id="v">
             <values>
                 <value>
                     <real>0.5</real>


### PR DESCRIPTION
Previous name was ambiguous - in most papers it is strictly named as 'v', and further in the explanation of the strategy for the selection of compromises, one of them is defined as 'with veto' in case of v < 0.5.