### PR TITLE
VIKOR_ranking: Add a validity constraint to parameter v (0≤v≤1)

### DIFF
--- a/vikor-compromises/description-wsDDv2.xml
+++ b/vikor-compromises/description-wsDDv2.xml
@@ -44,7 +44,12 @@ This module bases on VIKOR method, from step 3 as a continuation of module `VIKO
     </methodParameters>
 ]]></xmcda>
             <gui status="preferGUI">
-                <entry id="%1" type="float" displayName="v" />
+                <entry id="%1" type="float" displayName="v">
+                    <constraint>
+                        <description>A numeric value v, with 0≤v≤1</description>
+                        <code><![CDATA[ %1 >= 0 && %1 <= 1 ]]></code>
+                    </constraint>
+                </entry>
             </gui>
         </input>
 

--- a/vikor-compromises/description-wsDDv3.xml
+++ b/vikor-compromises/description-wsDDv3.xml
@@ -46,7 +46,12 @@ This module bases on VIKOR method, from step 3 as a continuation of module `VIKO
     </programParameters>
 ]]></xmcda>
             <gui status="preferGUI">
-                <entry id="%1" type="float" displayName="v" />
+                <entry id="%1" type="float" displayName="v">
+                    <constraint>
+                        <description>A numeric value v, with 0≤v≤1</description>
+                        <code><![CDATA[ %1 >= 0 && %1 <= 1 ]]></code>
+                    </constraint>
+                </entry>
             </gui>
         </input>
 


### PR DESCRIPTION
This adds the validity constraint 0≤v≤1 for parameter v in VIKOR_ranking
(cf. https://github.com/Azbesciak/DecisionDeck/blob/master/vikor-compromises/src/vikorCompromises.R#L46)